### PR TITLE
DownloadStream produce much more reliable outputs now. It is also now…

### DIFF
--- a/tests/config.go
+++ b/tests/config.go
@@ -2,4 +2,5 @@ package tests
 
 var (
 	USERNAME = "r_sciroc"
+	APIKEY   = ""
 )

--- a/tiktok.go
+++ b/tiktok.go
@@ -79,7 +79,7 @@ func NewTikTokWithApiKey(clientName, apiKey string, options ...TikTokLiveOption)
 		mu:              &sync.Mutex{},
 		infoHandler:     defaultLogHandler,
 		warnHandler:     defaultLogHandler,
-		debugHandler:    defaultLogHandler,
+		debugHandler:    routineErrHandler,
 		errHandler:      routineErrHandler,
 		signerUrl:       defaultSignerURL,
 		clientName:      clientName,

--- a/utils.go
+++ b/utils.go
@@ -5,12 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	pb "github.com/steampoweredtaco/gotiktoklive/proto"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 	"log/slog"
 	"math/rand"
-
-	"google.golang.org/protobuf/proto"
 )
 
 func getRandomDeviceID() string {


### PR DESCRIPTION
… blocking.

DownloadStream is blocking now.  Before it had no good way to tell when finished and to keep with idiomatic go, the caller of the library should make it async if required. This simplifies the complexity of the library and puts the check
 mechanism into the hands caller.